### PR TITLE
Skip product collection load for categories with display mode 'page'

### DIFF
--- a/Block/Category.php
+++ b/Block/Category.php
@@ -80,7 +80,11 @@ class Category extends Template implements MetadataInterface
             $category = $this->getCategory();
 
             if ($category) {
-                $productCollection = $this->getProductCollection();
+                $productCollection = null;
+                if ($category->getDisplayMode() != \Magento\Catalog\Model\Category::DM_PAGE) {
+                    $productCollection = $this->getProductCollection();
+                }
+
                 if (!$productCollection) {
                     // Ensure no records are returned if a product collection isn't already available
                     $productCollection = $this->productCollectionFactory->create();


### PR DESCRIPTION
This change will skip loading product collection if you choose 'Static block only' under the Display Settings > Display Mode in the category settings. 

This will drastically improve performance, espacially in websites with a huge number of products. 
As far as I understand the klevu metadata is interested in the products of a category only when they display in the front end. If not, it would be good to understand whats the purpose of the metadata.
